### PR TITLE
Remove apt-transport-https

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -30,7 +30,6 @@ _core_dependencies_packages:
     - shadow-utils
     - xz
   Debian:
-    - apt-transport-https
     - debconf
     - debconf-i18n
     - iproute2


### PR DESCRIPTION
This is a transitional package since buster and is not required anymore.